### PR TITLE
Projects Showcase page (cleanly re-applied on main)

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,0 +1,15 @@
+import ProjectCarousel3D from "@/components/project-carousel/ProjectCarousel";
+import { PROJECTS } from "@/data/projects";
+
+export const metadata = {
+  title: 'Projects | IoT Lab KIIT',
+  description: 'A showcase of engineering prowess, smart automation, and connected ecosystems from IoT Lab KIIT.',
+};
+
+export default function Page() {
+  return (
+    <main>
+      <ProjectCarousel3D projects={PROJECTS} />
+    </main>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -6,7 +6,7 @@ import { usePathname } from 'next/navigation';
 
 const links = [
   { href: '/', label: 'Home' },
-  { href: '/work', label: 'Projects' },
+  { href: '/projects', label: 'Projects' },
   { href: '/team', label: 'Team' },
   { href: '/gallery', label: 'Gallery' },
   { href: '/contact', label: 'Contact Us' },

--- a/components/project-carousel/ProjectCarousel.tsx
+++ b/components/project-carousel/ProjectCarousel.tsx
@@ -1,0 +1,497 @@
+"use client";
+
+import { motion, AnimatePresence, useMotionValue, useSpring, useTransform } from "framer-motion";
+import { Inter, JetBrains_Mono } from "next/font/google";
+import { ChevronLeft, ChevronRight, ExternalLink } from "lucide-react";
+import { useEffect, useMemo, useRef, useState, memo, useCallback } from "react";
+
+const inter = Inter({ subsets: ["latin"] });
+const mono = JetBrains_Mono({ subsets: ["latin"] });
+
+import { Project } from "@/data/projects";
+
+// --- Components ---
+
+const GithubIcon = ({ size = 24, className = "" }: { size?: number, className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
+    <path d="M9 18c-4.51 2-5-2-7-2" />
+  </svg>
+);
+
+const CanvasBackground = memo(function CanvasBackground() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
+
+    const ctx = canvas.getContext("2d", { alpha: true });
+    if (!ctx) return;
+
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    let animationFrameId: number;
+    let logicalWidth = 0;
+    let logicalHeight = 0;
+    let particles: Array<{ x: number; y: number; vx: number; vy: number; radius: number }> = [];
+
+    const mouse = { x: -1000, y: -1000, radius: 180 };
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      mouse.x = e.clientX - rect.left;
+      mouse.y = e.clientY - rect.top;
+    };
+
+    const handleMouseLeave = () => {
+      mouse.x = -1000;
+      mouse.y = -1000;
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseleave", handleMouseLeave);
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        const dpr = window.devicePixelRatio || 1;
+
+        canvas.width = width * dpr;
+        canvas.height = height * dpr;
+        canvas.style.width = `${width}px`;
+        canvas.style.height = `${height}px`;
+
+        ctx.scale(dpr, dpr);
+        logicalWidth = width;
+        logicalHeight = height;
+
+        const particleCount = Math.floor((width * height) / 9000);
+        particles = Array.from({ length: particleCount }).map(() => ({
+          x: Math.random() * width,
+          y: Math.random() * height,
+          vx: prefersReducedMotion ? 0 : (Math.random() - 0.5) * 0.8,
+          vy: prefersReducedMotion ? 0 : (Math.random() - 0.5) * 0.8,
+          radius: Math.random() * 2 + 1,
+        }));
+      }
+    });
+
+    resizeObserver.observe(container);
+
+    const render = () => {
+      ctx.clearRect(0, 0, logicalWidth, logicalHeight);
+
+      for (let i = 0; i < particles.length; i++) {
+        const p = particles[i];
+        p.x += p.vx;
+        p.y += p.vy;
+
+        if (p.x < 0 || p.x > logicalWidth) p.vx *= -1;
+        if (p.y < 0 || p.y > logicalHeight) p.vy *= -1;
+
+        const dx = mouse.x - p.x;
+        const dy = mouse.y - p.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+
+        if (dist < mouse.radius && !prefersReducedMotion) {
+          const angle = Math.atan2(dy, dx);
+          p.x += Math.cos(angle) * 0.5;
+          p.y += Math.sin(angle) * 0.5;
+        }
+
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, p.radius, 0, Math.PI * 2);
+        ctx.fillStyle = "rgba(0, 98, 255, 0.4)";
+        ctx.fill();
+
+        for (let j = i + 1; j < particles.length; j++) {
+          const p2 = particles[j];
+          const distance = Math.sqrt((p.x - p2.x) ** 2 + (p.y - p2.y) ** 2);
+          if (distance < 120) {
+            ctx.beginPath();
+            ctx.moveTo(p.x, p.y);
+            ctx.lineTo(p2.x, p2.y);
+            ctx.strokeStyle = `rgba(0, 98, 255, ${0.15 * (1 - distance / 120)})`;
+            ctx.lineWidth = 1;
+            ctx.stroke();
+          }
+        }
+
+        if (dist < mouse.radius) {
+          ctx.beginPath();
+          ctx.moveTo(p.x, p.y);
+          ctx.lineTo(mouse.x, mouse.y);
+          ctx.strokeStyle = `rgba(0, 98, 255, ${0.35 * (1 - dist / mouse.radius)})`; 
+          ctx.lineWidth = 1.2;
+          ctx.stroke();
+        }
+      }
+      animationFrameId = requestAnimationFrame(render);
+    };
+
+    render();
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseleave", handleMouseLeave);
+      resizeObserver.disconnect();
+      cancelAnimationFrame(animationFrameId);
+    };
+  }, []);
+
+  return (
+    <div ref={containerRef} className="absolute inset-0 z-0 overflow-hidden pointer-events-none" aria-hidden="true">
+      <canvas ref={canvasRef} className="block pointer-events-auto" />
+    </div>
+  );
+});
+
+type ProjectCardProps = {
+  project: Project;
+  isActive: boolean;
+  onClick: () => void;
+};
+
+const ProjectCard = memo(function ProjectCard({ project, isActive, onClick }: ProjectCardProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isHovered, setIsHovered] = useState(false);
+
+  const mouseX = useMotionValue(0.5);
+  const mouseY = useMotionValue(0.5);
+
+  const springConfig = { damping: 25, stiffness: 300, mass: 0.5 };
+  const smoothX = useSpring(mouseX, springConfig);
+  const smoothY = useSpring(mouseY, springConfig);
+
+  const rotateX = useTransform(smoothY, [0, 1], [12, -12]);
+  const rotateY = useTransform(smoothX, [0, 1], [-12, 12]);
+  const glareOpacity = useTransform(smoothY, [0, 0.5, 1], [0.2, 0, 0.2]);
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!isActive || !ref.current) return;
+    const rect = ref.current.getBoundingClientRect();
+    mouseX.set(Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)));
+    mouseY.set(Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height)));
+  };
+
+  const handleMouseLeaveWrapper = () => {
+    mouseX.set(0.5);
+    mouseY.set(0.5);
+    setIsHovered(false);
+  };
+
+  return (
+    <motion.div
+      ref={ref}
+      onMouseMove={handleMouseMove}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={handleMouseLeaveWrapper}
+      onClick={onClick}
+      style={{
+        rotateX: isActive ? rotateX : 0,
+        rotateY: isActive ? rotateY : 0,
+        transformStyle: "preserve-3d",
+      }}
+      className={`relative h-[480px] w-[340px] rounded-[32px] cursor-pointer will-change-transform ${isActive ? "z-50" : "z-10"}`}
+      aria-hidden={!isActive}
+    >
+      <motion.div
+        animate={{
+          scale: isActive ? 1 : 0.95,
+          boxShadow: isActive
+            ? "0 30px 80px rgba(0, 98, 255, 0.25), 0 0 0 1px rgba(0, 98, 255, 0.2)"
+            : "0 10px 30px rgba(0, 0, 0, 0.05), 0 0 0 1px rgba(255,255,255,0.5)"
+        }}
+        transition={{ type: "spring", stiffness: 300, damping: 25 }}
+        className="absolute inset-0 bg-white rounded-[32px] overflow-hidden flex flex-col"
+      >
+        <motion.div
+          className="absolute inset-0 z-[60] pointer-events-none rounded-[32px]"
+          style={{
+            background: "linear-gradient(105deg, transparent 20%, rgba(255,255,255,0.8) 50%, transparent 80%)",
+            opacity: isActive ? glareOpacity : 0,
+            mixBlendMode: "overlay"
+          }}
+        />
+
+        <AnimatePresence>
+          {isActive && isHovered && (
+            <motion.div
+              initial={{ opacity: 0, y: '100%' }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: '100%' }}
+              transition={{ type: "spring", damping: 25, stiffness: 250 }}
+              className="absolute inset-0 z-50 flex flex-col bg-slate-900/95 backdrop-blur-xl text-white p-8 overflow-hidden rounded-[32px]"
+            >
+              <motion.div
+                animate={{ rotate: 360 }}
+                transition={{ duration: 20, repeat: Infinity, ease: "linear" }}
+                className="absolute -top-24 -right-24 w-48 h-48 bg-blue-600/30 blur-[50px] rounded-full pointer-events-none"
+              />
+              <motion.div
+                animate={{ rotate: -360 }}
+                transition={{ duration: 15, repeat: Infinity, ease: "linear" }}
+                className="absolute -bottom-24 -left-24 w-48 h-48 bg-blue-400/30 blur-[50px] rounded-full pointer-events-none"
+              />
+
+              <div className="relative z-10 flex flex-col h-full">
+                <motion.h3
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.15 }}
+                  className="text-2xl font-bold tracking-tight mb-4 mt-2"
+                >
+                  {project.title}
+                </motion.h3>
+                <motion.div
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.2 }}
+                  className="text-sm leading-relaxed text-slate-300 mb-4 overflow-y-auto pr-2 flex-grow [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-indigo-500/50 [&::-webkit-scrollbar-thumb]:rounded-full"
+                >
+                  {project.description}
+                  {" "}This project showcases advanced integration of hardware and software, designed with a focus on scalability, real-time performance, and a seamless user experience.
+                </motion.div>
+
+                <div className="mt-auto flex flex-col gap-3 shrink-0 pt-2">
+                  {project.github && (
+                    <motion.a
+                      initial={{ opacity: 0, y: 10 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ delay: 0.25 }}
+                      whileTap={{ scale: 0.95 }}
+                      href={project.github}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="flex items-center justify-center gap-2 w-full py-3 px-4 bg-white text-slate-900 rounded-xl font-bold transition-all hover:bg-slate-100 hover:scale-[1.02] active:bg-slate-900 active:text-white"
+                      onClick={(e: any) => e.stopPropagation()}
+                    >
+                      <GithubIcon size={18} /> View on Github
+                    </motion.a>
+                  )}
+                  <motion.a
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: 0.3 }}
+                    whileTap={{ scale: 0.95 }}
+                    href={project.link}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="flex items-center justify-center gap-2 w-full py-3 px-4 bg-white/10 text-white rounded-xl font-bold transition-all hover:bg-white/20 hover:scale-[1.02] border border-white/10 active:bg-white active:text-slate-900"
+                    onClick={(e: any) => e.stopPropagation()}
+                  >
+                    <ExternalLink size={18} /> Live
+                  </motion.a>
+                </div>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        <div className="relative h-[55%] w-full bg-slate-100 overflow-hidden">
+          <img
+            src={project.image}
+            alt={`Screenshot of ${project.title}`}
+            className="absolute inset-0 h-full w-full object-cover transition-transform duration-700 ease-out hover:scale-105"
+            loading="lazy"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent" />
+        </div>
+
+        <div className="flex-grow p-6 flex flex-col justify-between bg-white">
+          <div>
+            <h3 className="text-xl font-bold tracking-tight text-slate-900 mt-2">
+              {project.title}
+            </h3>
+            <p className="mt-2 text-sm leading-relaxed text-slate-500 line-clamp-2">
+              {project.description}
+            </p>
+            <p className="mt-1 text-xs font-semibold text-indigo-500 hover:text-indigo-700 transition-colors cursor-pointer inline-flex items-center gap-1">
+              Read more <ChevronRight size={14} className="inline" />
+            </p>
+          </div>
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+});
+
+/**
+ * Main Carousel Orchestrator Component
+ */
+export default function PolishedProjectShowcase({ projects }: { projects: Project[] }) {
+  const [active, setActive] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+  const autoplayRef = useRef<NodeJS.Timeout>();
+
+  const next = useCallback(() => setActive((p) => (p + 1) % projects.length), [projects]);
+  const prev = useCallback(() => setActive((p) => (p - 1 + projects.length) % projects.length), [projects]);
+
+  useEffect(() => {
+    if (!isPaused) {
+      autoplayRef.current = setInterval(next, 6000);
+    }
+    return () => clearInterval(autoplayRef.current);
+  }, [next, isPaused]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "ArrowRight") { next(); setIsPaused(true); }
+      if (e.key === "ArrowLeft") { prev(); setIsPaused(true); }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [next, prev]);
+
+  const orderedItems = useMemo(() => {
+    return projects.map((item, index) => {
+      let offset = index - active;
+      // Handle the wrapping logic for infinite loop
+      if (offset > 2) offset -= projects.length;
+      if (offset < -2) offset += projects.length;
+      return { ...item, offset };
+    });
+  }, [active, projects]);
+
+  return (
+    <section
+      className={`${inter.className} relative w-full min-h-screen py-16 md:py-24 flex flex-col justify-between overflow-hidden bg-slate-50`}
+      style={{ backgroundImage: "linear-gradient(135deg, #E0EBFF 0%, #C7DCFF 100%)" }}
+      aria-label="Featured Projects Showcase"
+    >
+      <CanvasBackground />
+
+      <div aria-live="polite" className="sr-only">
+        Currently displaying project {active + 1} of {projects.length}: {projects[active]?.title}.
+      </div>
+
+      <div className="relative z-10 mx-auto max-w-7xl px-6 md:px-8 w-full flex-grow flex flex-col justify-center">
+
+        {/* Minimalist, Cinematic Header */}
+        <header className="mb-12 md:mb-16 text-center relative z-20">
+          <motion.div
+            initial={{ opacity: 0, y: 15 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, ease: "easeOut" }}
+            className="flex items-center justify-center gap-4 mb-4"
+          >
+            <div className="h-[1px] w-8 bg-gradient-to-r from-transparent to-blue-500/50" />
+            <p className={`${mono.className} text-xs uppercase tracking-[0.3em] font-semibold text-blue-600/80`}>
+              Featured Projects
+            </p>
+            <div className="h-[1px] w-8 bg-gradient-to-l from-transparent to-blue-500/50" />
+          </motion.div>
+
+          <motion.h2
+            initial={{ opacity: 0, y: 15 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.1, ease: "easeOut" }}
+            className="text-4xl font-extrabold tracking-tight md:text-5xl lg:text-6xl text-slate-900"
+          >
+            Crafted for <span className="inline-block bg-gradient-to-r from-[#0062FF] to-[#00B3FF] bg-clip-text text-transparent">Innovation</span>
+          </motion.h2>
+
+          <motion.p
+            initial={{ opacity: 0, y: 15 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.2, ease: "easeOut" }}
+            className="mx-auto mt-4 max-w-2xl text-base md:text-lg text-slate-600 leading-relaxed"
+          >
+            A high-performance showcase of engineering prowess, smart automation, and connected ecosystems.
+          </motion.p>
+        </header>
+
+        <div
+          className="relative mx-auto h-[520px] flex items-center justify-center w-full"
+          style={{ perspective: "2500px", transformStyle: "preserve-3d" }}
+          role="region"
+          aria-roledescription="carousel"
+        >
+          {/* Ambient Floor Glow: Grounds the 3D cards so they don't look like they are floating in nowhere */}
+          <div className="absolute -bottom-16 left-1/2 -translate-x-1/2 w-3/4 max-w-[600px] h-24 bg-blue-500/20 blur-[50px] rounded-full pointer-events-none" />
+
+          {orderedItems.map((project) => {
+            const isActive = project.offset === 0;
+            const x = project.offset * 320;
+            const rotateY = project.offset * -12;
+            const scale = isActive ? 1 : 0.85;
+            const z = isActive ? 100 : 50 - Math.abs(project.offset) * 20;
+            const opacity = Math.abs(project.offset) > 2 ? 0 : 1;
+
+            return (
+              <motion.div
+                key={project.id}
+                animate={{ x, rotateY, scale, zIndex: z, opacity }}
+                transition={{ type: "spring", stiffness: 150, damping: 22 }}
+                className="absolute"
+                style={{ transformStyle: "preserve-3d", transformOrigin: "center center" }}
+              >
+                <ProjectCard
+                  project={project}
+                  isActive={isActive}
+                  onClick={() => {
+                    setActive(projects.findIndex(p => p.id === project.id));
+                    setIsPaused(true);
+                  }}
+                />
+              </motion.div>
+            );
+          })}
+        </div>
+
+        <nav className="mt-12 flex items-center justify-center gap-6 z-20" aria-label="Carousel Pagination">
+          <button
+            onClick={() => { prev(); setIsPaused(true); }}
+            className="flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-sm border border-blue-100 text-slate-700 transition-all hover:bg-slate-50 active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+            aria-label="Previous project"
+          >
+            <ChevronLeft size={20} />
+          </button>
+
+          <div className="flex items-center gap-3">
+            {projects.map((_, i) => (
+              <button
+                key={i}
+                onClick={() => { setActive(i); setIsPaused(true); }}
+                className="py-3 px-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-md transition-transform active:scale-95"
+                aria-label={`Go to project ${i + 1}`}
+                aria-current={active === i ? "true" : "false"}
+              >
+                <motion.div
+                  animate={{
+                    width: active === i ? 36 : 8,
+                    backgroundColor: active === i ? "#0062FF" : "rgba(0, 98, 255, 0.25)"
+                  }}
+                  className="h-2 rounded-full"
+                />
+              </button>
+            ))}
+          </div>
+
+          <button
+            onClick={() => { next(); setIsPaused(true); }}
+            className="flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-sm border border-blue-100 text-slate-700 transition-all hover:bg-slate-50 active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+            aria-label="Next project"
+          >
+            <ChevronRight size={20} />
+          </button>
+        </nav>
+
+      </div>
+    </section>
+  );
+}

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -1,0 +1,55 @@
+export interface Project {
+  id: number;
+  title: string;
+  category: string;
+  description: string;
+  image: string;
+  link: string;
+  github?: string;
+}
+
+export const PROJECTS: Project[] = [
+  {
+    id: 1,
+    title: "IoT Dashboard",
+    category: "Analytics",
+    description: "Real-time analytics dashboard with modern UI and responsive monitoring.   lorem ipfewjnnnnnnnnnnnnnnnnnnnnnnnwef we fwejf jwe fwe fjwe fjwe f wejf wej fweh fjweh fjwe ajb fj bawfjb ewfjl wjelf jlweb afljb fljebw fljba wfljbe wflj awljf ewlajf elwj fljwa fljwb fljewa fljwbe fljbw eflwej fljaw ef waef webf w fajbw efj awljbf ljb ewf ewf alwje fj;w flja fljwae flj we;fjal fljwa efj aflj ewf aljf ljwea fljwa flewj flewa lje f efef ef   e lE FLJWEFLJ LJF eljf LJ FLJEbf jle FJE",
+    image: "https://images.unsplash.com/photo-1551288049-bebda4e38f71?q=80&w=800&auto=format&fit=crop",
+    link: "#",
+    github: "https://github.com",
+  },
+  {
+    id: 2,
+    title: "Industrial IoT",
+    category: "Automation",
+    description: "Industrial monitoring powered by AI and predictive analytics.",
+    image: "https://images.unsplash.com/photo-1581091226825-a6a2a5aee158?q=80&w=800&auto=format&fit=crop",
+    link: "#",
+  },
+  {
+    id: 3,
+    title: "Embedded Project",
+    category: "Embedded",
+    description: "Embedded hardware engineered with precision and reliability.",
+    image: "https://images.unsplash.com/photo-1518770660439-4636190af475?q=80&w=800&auto=format&fit=crop",
+    link: "#",
+    github: "https://github.com",
+  },
+  {
+    id: 4,
+    title: "Robotics",
+    category: "AI",
+    description: "Autonomous robotics with computer vision and intelligent control.",
+    image: "https://images.unsplash.com/photo-1485827404703-89b55fcc595e?q=80&w=800&auto=format&fit=crop",
+    link: "#",
+    github: "https://github.com",
+  },
+  {
+    id: 5,
+    title: "Smart Campus",
+    category: "IoT",
+    description: "Connected campus infrastructure with live monitoring.",
+    image: "https://images.unsplash.com/photo-1573164713988-8665fc963095?q=80&w=800&auto=format&fit=crop",
+    link: "#",
+  },
+];

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "framer-motion": "^12.43.0",
     "isomorphic-dompurify": "^3.18.0",
     "lottie-react": "^2.4.0",
+    "lucide-react": "^1.30.0",
     "next": "13.5.3",
     "postcss": "8.4.30",
     "react": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -363,7 +363,7 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@mui/base@^5.0.0-beta.17", "@mui/base@5.0.0-beta.19":
+"@mui/base@5.0.0-beta.19", "@mui/base@^5.0.0-beta.17":
   version "5.0.0-beta.19"
   resolved "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.19.tgz"
   integrity sha512-maNBgAscddyPNzFZQUJDF/puxM27Li+NqSBsr/lAP8TLns2VvWS2SoL3OKFOIoRnAMKGY/Ic6Aot6gCYeQnssA==
@@ -502,6 +502,46 @@
   dependencies:
     glob "7.1.7"
 
+"@next/swc-darwin-arm64@13.5.3":
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.3.tgz#f72eac8c7b71d33e0768bd3c8baf68b00fea0160"
+  integrity sha512-6hiYNJxJmyYvvKGrVThzo4nTcqvqUTA/JvKim7Auaj33NexDqSNwN5YrrQu+QhZJCIpv2tULSHt+lf+rUflLSw==
+
+"@next/swc-darwin-x64@13.5.3":
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.3.tgz#96eda3a1247a713579eb241d76d3f503291c8938"
+  integrity sha512-UpBKxu2ob9scbpJyEq/xPgpdrgBgN3aLYlxyGqlYX5/KnwpJpFuIHU2lx8upQQ7L+MEmz+fA1XSgesoK92ppwQ==
+
+"@next/swc-linux-arm64-gnu@13.5.3":
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.3.tgz#132e155a029310fffcdfd3e3c4255f7ce9fd2714"
+  integrity sha512-5AzM7Yx1Ky+oLY6pHs7tjONTF22JirDPd5Jw/3/NazJ73uGB05NqhGhB4SbeCchg7SlVYVBeRMrMSZwJwq/xoA==
+
+"@next/swc-linux-arm64-musl@13.5.3":
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.3.tgz#981d7d8fdcf040bd0c89588ef4139c28805f5cf1"
+  integrity sha512-A/C1shbyUhj7wRtokmn73eBksjTM7fFQoY2v/0rTM5wehpkjQRLOXI8WJsag2uLhnZ4ii5OzR1rFPwoD9cvOgA==
+
+"@next/swc-linux-x64-gnu@13.5.3":
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.3.tgz#b8263663acda7b84bc2c4ffa39ca4b0172a78060"
+  integrity sha512-FubPuw/Boz8tKkk+5eOuDHOpk36F80rbgxlx4+xty/U71e3wZZxVYHfZXmf0IRToBn1Crb8WvLM9OYj/Ur815g==
+
+"@next/swc-linux-x64-musl@13.5.3":
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.3.tgz#cd0bed8ee92032c25090bed9d95602ac698d925f"
+  integrity sha512-DPw8nFuM1uEpbX47tM3wiXIR0Qa+atSzs9Q3peY1urkhofx44o7E1svnq+a5Q0r8lAcssLrwiM+OyJJgV/oj7g==
+
+"@next/swc-win32-arm64-msvc@13.5.3":
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.3.tgz#7f556674ca97e6936220d10c58252cc36522d80a"
+  integrity sha512-zBPSP8cHL51Gub/YV8UUePW7AVGukp2D8JU93IHbVDu2qmhFAn9LWXiOOLKplZQKxnIPUkJTQAJDCWBWU4UWUA==
+
+"@next/swc-win32-ia32-msvc@13.5.3":
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.3.tgz#4912721fb8695f11daec4cde42e73dc57bcc479f"
+  integrity sha512-ONcL/lYyGUj4W37D4I2I450SZtSenmFAvapkJQNIJhrPMhzDU/AdfLkW98NvH1D2+7FXwe7yclf3+B7v28uzBQ==
+
 "@next/swc-win32-x64-msvc@13.5.3":
   version "13.5.3"
   resolved "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.3.tgz"
@@ -515,7 +555,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -966,7 +1006,7 @@ chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-client-only@^0.0.1, client-only@0.0.1:
+client-only@0.0.1, client-only@^0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
@@ -990,15 +1030,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@^1.0.8:
   version "1.0.8"
@@ -1650,6 +1690,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.1:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -1695,7 +1740,7 @@ get-tsconfig@^4.5.0:
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
-glob-parent@^5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -1709,22 +1754,15 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob-parent@~5.1.2:
-  version "5.1.2"
-  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
-  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
-  dependencies:
-    is-glob "^4.0.1"
-
 glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@^7.1.3, glob@7.1.7:
-  version "7.1.7"
-  resolved "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz"
-  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+glob@7.1.6:
+  version "7.1.6"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1733,10 +1771,10 @@ glob@^7.1.3, glob@7.1.7:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.6:
-  version "7.1.6"
-  resolved "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+glob@7.1.7, glob@^7.1.3:
+  version "7.1.7"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -2237,7 +2275,7 @@ jss-plugin-vendor-prefixer@^10.10.0:
     css-vendor "^2.0.8"
     jss "10.10.0"
 
-jss@^10.10.0, jss@10.10.0:
+jss@10.10.0, jss@^10.10.0:
   version "10.10.0"
   resolved "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz"
   integrity sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==
@@ -2337,6 +2375,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lucide-react@^1.30.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-1.30.0.tgz#4b34d6a2b4b75fdf6aea0df4147d4fa80ae5ddbd"
+  integrity sha512-tUIr2jXLbWpCkdtH8XP7P7YppM9ueWgTky99lpWDY6z5REs6B+O6ZQ3U5tHkUUY59ANyOv/PBcs8E4Fe3KO3eA==
+
 mdn-data@2.27.1:
   version "2.27.1"
   resolved "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz"
@@ -2391,7 +2434,7 @@ motion-utils@^12.39.0:
   resolved "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz"
   integrity sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==
 
-ms@^2.1.1, ms@2.1.2:
+ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -2675,21 +2718,21 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.23, postcss@8.4.30:
-  version "8.4.30"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz"
-  integrity sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==
-  dependencies:
-    nanoid "^3.3.6"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
-
 postcss@8.4.14:
   version "8.4.14"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz"
   integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==
   dependencies:
     nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
+postcss@8.4.30, postcss@^8.4.23:
+  version "8.4.30"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz"
+  integrity sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==
+  dependencies:
+    nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
@@ -2740,12 +2783,7 @@ react-icons@^4.11.0:
   resolved "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz"
   integrity sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==
 
-react-is@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react-is@^16.7.0:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -2915,12 +2953,7 @@ scheduler@^0.23.0:
   dependencies:
     loose-envify "^1.1.0"
 
-semver@^6.3.0:
-  version "6.3.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
-semver@^6.3.1:
+semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==


### PR DESCRIPTION
## Summary
Rebuilds the projects showcase on top of **current main** (the original `feature/projects-page` / PR #47 could no longer merge: it conflicted on `Navbar.tsx`, `app/layout.tsx`, `package.json`, `yarn.lock`, all of which moved after it was branched).

## What changed (conflict resolution)
- `app/projects/page.tsx`, `components/project-carousel/ProjectCarousel.tsx`, `data/projects.ts` — ported verbatim from PR #47.
- `components/Navbar.tsx` — repointed the existing **Projects** link from `/work` (a "coming soon" placeholder) to the new `/projects` route instead of adding a second Projects entry.
- `package.json` / `yarn.lock` — added only **`lucide-react`** (used by the carousel). `framer-motion@12.43.0` was already present in main. **Dropped `keen-slider`**: the carousel never imports it, so it was an unused dep in the original PR.
- Added route `metadata` to match site conventions.

## Merge order (important)
Repo already modifies `package.json`/`yarn.lock` on several branches. Merge **this PR first**, then `alumni-redesign` (PR that follows) — both touch `package.json`/`yarn.lock`, and this one must land so the alumni branch can rebase cleanly.

## Verification
- `tsc --noEmit` ✅
- `yarn build` ✅ (/projects 51 kB route compiles)