### PR TITLE
Alumni page redesign (cleanly re-applied on main, search preserved)

### DIFF
--- a/app/alumni/page.tsx
+++ b/app/alumni/page.tsx
@@ -17,7 +17,7 @@ const leads = alumni.filter((a) => a.tier === 'lead');
 const mentors = alumni.filter((a) => a.tier === 'mentor');
 const members = alumni.filter((a) => a.tier === 'member');
 
-// NEW: Complete alumni list for the searchable directory
+// Complete alumni list for the searchable directory
 const allMembers = alumni;
 
 const Alumni = () => {
@@ -67,11 +67,11 @@ const Alumni = () => {
 
       {/* Coordinators */}
       {coordinators.length > 0 && (
-        <section className="mx-auto max-w-6xl px-6 py-16">
+        <section className="mx-auto max-w-7xl px-8 py-16 lg:px-12">
           <SectionTitle eyebrow="Leadership" title="Coordinators" />
 
           <Stagger
-            className="mx-auto grid max-w-4xl grid-cols-2 gap-6 sm:grid-cols-3 sm:gap-8 md:grid-cols-5"
+            className="grid grid-cols-1 justify-items-center gap-x-16 gap-y-20 sm:grid-cols-2 lg:grid-cols-5"
             childClassName="h-full"
             step={60}
           >
@@ -85,11 +85,11 @@ const Alumni = () => {
       {/* Leads */}
       {leads.length > 0 && (
         <section className="bg-primary-50/40 py-16">
-          <div className="mx-auto max-w-6xl px-6">
+          <div className="mx-auto max-w-7xl px-8 lg:px-12">
             <SectionTitle eyebrow="Core Team" title="Team Leads" />
 
             <Stagger
-              className="mx-auto grid max-w-4xl grid-cols-2 gap-6 sm:grid-cols-3 sm:gap-8 md:grid-cols-4"
+              className="grid grid-cols-1 justify-items-center gap-x-16 gap-y-20 sm:grid-cols-2 lg:grid-cols-5"
               childClassName="h-full"
               step={60}
             >
@@ -103,11 +103,11 @@ const Alumni = () => {
 
       {/* Mentors */}
       {mentors.length > 0 && (
-        <section className="mx-auto max-w-6xl px-6 py-16">
+        <section className="mx-auto max-w-7xl px-8 py-16 lg:px-12">
           <SectionTitle eyebrow="Guidance" title="Mentors & Advisors" />
 
           <Stagger
-            className="grid grid-cols-2 gap-6 sm:grid-cols-4 sm:gap-8 md:grid-cols-6"
+            className="grid grid-cols-2 justify-items-center gap-x-16 gap-y-16 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
             childClassName="h-full"
             step={60}
           >
@@ -121,14 +121,14 @@ const Alumni = () => {
       {/* Members */}
       {members.length > 0 && (
         <section className="bg-primary-50/40 py-16">
-          <div className="mx-auto max-w-6xl px-6">
+          <div className="mx-auto max-w-7xl px-8 lg:px-12">
             <SectionTitle
               eyebrow="The Family"
               title="Members"
               subtitle="People from the previous batch who were part of the lab."
             />
 
-            {/* CHANGED: Pass all alumni instead of only members */}
+            {/* Pass all alumni instead of only members */}
             <MemberSearch members={allMembers} />
           </div>
         </section>

--- a/components/alumni/MemberSearch.tsx
+++ b/components/alumni/MemberSearch.tsx
@@ -126,7 +126,7 @@ const MemberSearch = ({ members }: Props) => {
       {/* Results */}
       {filteredMembers.length > 0 ? (
         <Stagger
-          className="grid grid-cols-2 gap-6 sm:grid-cols-3 sm:gap-8 md:grid-cols-4 lg:grid-cols-5"
+          className="grid grid-cols-2 justify-items-center gap-x-14 gap-y-16 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
           childClassName="h-full"
           step={60}
         >

--- a/components/team/AlumCard.tsx
+++ b/components/team/AlumCard.tsx
@@ -1,61 +1,324 @@
 import type { Alum } from '@/data/alumni';
+import { createAvatar } from '@dicebear/core';
+import { initials } from '@dicebear/collection';
 
 const normalize = (url: string) =>
   url.startsWith('http') ? url : `https://${url}`;
+const AlumCard = ({
+  alum,
+  featured = false,
+}: {
+  alum: Alum;
+  featured?: boolean;
+}) => {
+  const avatarSvg = createAvatar(initials, {
+    seed: alum.name,
+    backgroundColor: ['2563eb'],
+    textColor: ['ffffff'],
+    fontWeight: 600,
+  }).toDataUri();
 
-// Alumni photos couldn't be recovered from the old CMS, so rather than a page
-// full of identical placeholders we use a clean, text-only card: name, role and
-// socials. A slim accent bar carries the brand colour and gives leads a touch
-// more visual weight than plain members.
-const AlumCard = ({ alum, featured = false }: { alum: Alum; featured?: boolean }) => {
+  const hasSocials = alum.linkedin || alum.github;
+
+  const SocialIcons = ({ onImage = false }: { onImage?: boolean }) => {
+    const iconClass = onImage
+      ? `
+          rounded-full
+          p-2
+          text-blue-700
+          bg-white
+          shadow-md
+          ring-1
+          ring-black/5
+
+          transition-colors
+          duration-300
+
+          hover:bg-blue-700
+          hover:text-white
+        `
+      : `
+          rounded-full
+          p-2
+          text-gray-500
+
+          transition-all
+          duration-300
+
+          hover:scale-110
+          hover:bg-blue-700
+          hover:text-white
+        `;
+
+    return (
+      <>
+        {/* LinkedIn */}
+        {alum.linkedin && (
+          <a
+            href={normalize(alum.linkedin)}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`${alum.name} on LinkedIn`}
+            className={iconClass}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1s2.48 1.12 2.48 2.5zM.5 8h4V23h-4V8zm7.5 0h3.8v2.05h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.78 2.65 4.78 6.1V23h-4v-6.6c0-1.57-.03-3.6-2.2-3.6-2.2 0-2.53 1.72-2.53 3.49V23H8V8z" />
+            </svg>
+          </a>
+        )}
+
+        {/* GitHub */}
+        {alum.github && (
+          <a
+            href={normalize(alum.github)}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`${alum.name} on GitHub`}
+            className={iconClass}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.2 11.39.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.2.09 1.84 1.24 1.84 1.24 1.07 1.83 2.81 1.3 3.5.99.11-.78.42-1.3.76-1.6-2.67-.3-5.47-1.34-5.47-5.95 0-1.32.47-2.39 1.24-3.23-.13-.3-.54-1.53.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.65.25 2.88.12 3.18.77.84 1.24 1.91 1.24 3.23 0 4.62-2.81 5.64-5.49 5.94.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58A12 12 0 0 0 24 12.5C24 5.87 18.63.5 12 .5z" />
+            </svg>
+          </a>
+        )}
+      </>
+    );
+  };
+
   return (
-    <div className="group relative flex h-full flex-col overflow-hidden rounded-xl border border-gray-100 bg-white p-6 text-center shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-primary-200 hover:shadow-lg">
+    <div
+      className={`
+        group
+        relative
+        flex
+        flex-col
+        overflow-hidden
+        rounded-2xl
+        border
+        border-gray-100
+        bg-white
+        text-center
+        shadow-sm
+
+        transition-all
+        duration-500
+        ease-out
+
+        hover:-translate-y-2
+        hover:border-blue-700
+        hover:shadow-xl
+
+        ${featured ? 'h-[300px] w-[220px]' : 'h-[260px] w-[230px] p-4'}
+      `}
+    >
+      {/* Animated Accent */}
       <span
-        className={`absolute inset-x-0 top-0 h-1 ${
-          featured ? 'bg-primary-default' : 'bg-primary-100'
-        }`}
+        className="
+          absolute
+          left-0
+          top-0
+          z-20
+          h-1
+          w-0
+          bg-blue-700
+
+          transition-all
+          duration-500
+
+          group-hover:w-full
+        "
       />
-      <p
-        className={`font-semibold tracking-tight text-gray-900 ${
-          featured ? 'text-base' : 'text-sm'
-        }`}
-      >
-        {alum.name}
-      </p>
-      {alum.role && (
-        <p className="mt-1 text-xs font-medium uppercase tracking-wide text-primary-500">
-          {alum.role}
-        </p>
-      )}
-      {(alum.linkedin || alum.github) && (
-        <div className="mt-4 flex items-center justify-center gap-3">
-          {alum.linkedin && (
-            <a
-              href={normalize(alum.linkedin)}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={`${alum.name} on LinkedIn`}
-              className="text-gray-400 transition-colors hover:text-primary-default"
+
+      {/* COORDINATORS / LEADS */}
+      {featured ? (
+        <>
+          <div
+            className="
+              relative
+              h-[75%]
+              w-full
+              overflow-hidden
+            "
+          >
+            <img
+              src={alum.image || avatarSvg}
+              alt={alum.name}
+              className="
+    h-full
+    w-full
+    object-cover
+
+    transition-transform
+    duration-700
+
+    group-hover:scale-110
+  "
+            />
+
+            {/* Social icons overlaid on the photo */}
+            {hasSocials && (
+              <div
+                className="
+                  absolute
+                  bottom-3
+                  left-1/2
+
+                  flex
+                  -translate-x-1/2
+                  gap-3
+
+                  translate-y-3
+                  opacity-0
+
+                  transition-all
+                  duration-500
+
+                  group-hover:translate-y-0
+                  group-hover:opacity-100
+                "
+              >
+                <SocialIcons onImage />
+              </div>
+            )}
+          </div>
+
+          {/* Text block below the photo */}
+          <div
+            className="
+              flex
+              flex-1
+              flex-col
+              items-center
+              justify-center
+              px-2
+              py-0.5
+              leading-tight
+            "
+          >
+            <h3
+              className="
+                text-sm
+                font-bold
+                tracking-tight
+                text-gray-900
+
+                transition-all
+                duration-300
+
+                group-hover:text-blue-700
+              "
             >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1s2.48 1.12 2.48 2.5zM.5 8h4V23h-4V8zm7.5 0h3.8v2.05h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.78 2.65 4.78 6.1V23h-4v-6.6c0-1.57-.03-3.6-2.2-3.6-2.2 0-2.53 1.72-2.53 3.49V23H8V8z" />
-              </svg>
-            </a>
-          )}
-          {alum.github && (
-            <a
-              href={normalize(alum.github)}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={`${alum.name} on GitHub`}
-              className="text-gray-400 transition-colors hover:text-primary-default"
+              {alum.name}
+            </h3>
+
+            {alum.role && (
+              <p
+                className="
+                  text-[11px]
+                  font-semibold
+                  text-blue-700
+                "
+              >
+                {alum.role}
+              </p>
+            )}
+          </div>
+        </>
+      ) : (
+        /* MEMBERS */
+        <>
+          <div
+            className="
+              mx-auto
+              h-40
+              w-40
+              overflow-hidden
+              rounded-full
+              border-4
+              border-gray-100
+
+              transition-all
+              duration-500
+
+              group-hover:border-blue-700
+              group-hover:shadow-lg
+            "
+          >
+            <img
+              src={alum.image || avatarSvg}
+              alt={alum.name}
+              className="
+    h-full
+    w-full
+    object-cover
+
+    transition-transform
+    duration-700
+
+    group-hover:scale-110
+  "
+            />
+          </div>
+
+          <h3
+            className="
+              mt-4
+              text-sm
+              font-semibold
+              tracking-tight
+              text-gray-900
+
+              transition-all
+              duration-300
+
+              group-hover:-translate-y-1
+              group-hover:text-blue-700
+            "
+          >
+            {alum.name}
+          </h3>
+
+          {alum.role && (
+            <p
+              className="
+                mt-1
+                text-[10px]
+                font-medium
+                uppercase
+                tracking-widest
+                text-blue-700
+              "
             >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.2 11.39.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.2.09 1.84 1.24 1.84 1.24 1.07 1.83 2.81 1.3 3.5.99.11-.78.42-1.3.76-1.6-2.67-.3-5.47-1.34-5.47-5.95 0-1.32.47-2.39 1.24-3.23-.13-.3-.54-1.53.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.65.25 2.88.12 3.18.77.84 1.24 1.91 1.24 3.23 0 4.62-2.81 5.64-5.49 5.94.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58A12 12 0 0 0 24 12.5C24 5.87 18.63.5 12 .5z" />
-              </svg>
-            </a>
+              {alum.role}
+            </p>
           )}
-        </div>
+
+          {/* Social icons below (members) */}
+          {hasSocials && (
+            <div
+              className="
+                absolute
+                bottom-2
+                left-1/2
+
+                flex
+                -translate-x-1/2
+                gap-3
+
+                translate-y-5
+                opacity-0
+
+                transition-all
+                duration-500
+
+                group-hover:translate-y-0
+                group-hover:opacity-100
+              "
+            >
+              <SocialIcons />
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/data/alumni.ts
+++ b/data/alumni.ts
@@ -5,6 +5,7 @@ export interface Alum {
   name: string;
   role?: string;
   tier: "coordinator" | "lead" | "mentor" | "member";
+  image?: string;
   linkedin?: string;
   github?: string;
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "prettier-fix": "prettier --write \"{app,components,container}/**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@dicebear/collection": "9.4.2",
+    "@dicebear/core": "9.4.2",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@headlessui/react": "^1.7.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,6 +134,205 @@
   resolved "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz"
   integrity sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==
 
+"@dicebear/adventurer-neutral@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/adventurer-neutral/-/adventurer-neutral-9.4.2.tgz#5779570b1c0fd956781fab2e2b09da7cac3b699d"
+  integrity sha512-5xgkG/mNL4j3Q4SJGQLBU/KnU90tng8Ze5ofThD+55wi0oeY/nSAUowg6UFCmHrktjifj/MEx3CQqbpcPWtfIA==
+
+"@dicebear/adventurer@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/adventurer/-/adventurer-9.4.2.tgz#5aa010ec20c49bcca936ce08e240bf7b888ff3bd"
+  integrity sha512-jqYp834ZmGDA9HBBDQAdgF1O2UTCwHF4vVrktXWa2Dppp1JczPL5HnVOWsjtrLmXNn61Wd6OLmBb2e6rhzp3ig==
+
+"@dicebear/avataaars-neutral@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/avataaars-neutral/-/avataaars-neutral-9.4.2.tgz#5db00cb9e5404aff10879672699aaa57e48e0129"
+  integrity sha512-/eNrp0YCNJRwQXqOloLm1+3Ss2C+pMpUQIGkbEnGsP1UK+13Ge80ggDDof1HpdqvG9HAZcKa7hnbG/0HSwyDSw==
+
+"@dicebear/avataaars@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/avataaars/-/avataaars-9.4.2.tgz#94c3b1d86101e4ad9122ad0f13cf2f7ac39c2aad"
+  integrity sha512-3x9jKFkOkFSPmpTbt9xvhiU2E1GX7beCSsX0tXRUShj8x6+5Ks9yBRT1VlkySbnXrZ/GglADGg7vJ/D2uIx1Yw==
+
+"@dicebear/big-ears-neutral@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/big-ears-neutral/-/big-ears-neutral-9.4.2.tgz#f8d6cdae3baa348a339d8047efc2e2ea4b1a074d"
+  integrity sha512-M8Ozmzza4eY4hpLOYULgJxMYmBA0CsBnrE15/xw6LZkEREXnrX5z0NJsf8hUfdyF6BWZ+RBgzoiav32DAC5zcg==
+
+"@dicebear/big-ears@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/big-ears/-/big-ears-9.4.2.tgz#65d32bac804f4bb615cf9afaba667e35e40565e1"
+  integrity sha512-mNfz3ppNA7UBq0IO3nXCiV5pFPG7c1DfzRB0foNU2Wo1XXT8FIcSY2BvDlYqorZTOUOz7dHb0vx06hqvG0HP5w==
+
+"@dicebear/big-smile@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/big-smile/-/big-smile-9.4.2.tgz#137f9a5b54f62291f2fc36da626125806afb6dcc"
+  integrity sha512-hmT5i7rcPPhStjZyg28pbIhdTnnMBzK3RObI0vKCpY30EFrzaPkkdDL6Ck5fAFBdvDIW1EpOJkenyR0XPmhgbQ==
+
+"@dicebear/bottts-neutral@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/bottts-neutral/-/bottts-neutral-9.4.2.tgz#a9ce66d50e600a9ee508fece651817b050406ff2"
+  integrity sha512-kFNwWt6j+gzZ5n5Pz7WVwePubREAQOF8ZwWA9ztwVYDVMLnOChWbAofy5FED4j5md2MXFH2EgLCFCMr5K2BmIA==
+
+"@dicebear/bottts@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/bottts/-/bottts-9.4.2.tgz#df7501723d309011e31b122484cfcef643a01f98"
+  integrity sha512-tsx+dII7EFUCVA8URj66G1GqORCCVduCAx4dY2prEY2IeFianVpkntXuFsWZ9BBGx1NZFndvDith5oTwKMQPbQ==
+
+"@dicebear/collection@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/collection/-/collection-9.4.2.tgz#16495cd2788614aaf2c783e539125b0dbf14bbe1"
+  integrity sha512-KArubv7if8H7j9sIfpDK2hJJqrdNVR5zMPAMOSpIU2JPyXx8TC9o5wsmXb8il5wOHgaS9Q/cla7jUNIiDD7Gsg==
+  dependencies:
+    "@dicebear/adventurer" "9.4.2"
+    "@dicebear/adventurer-neutral" "9.4.2"
+    "@dicebear/avataaars" "9.4.2"
+    "@dicebear/avataaars-neutral" "9.4.2"
+    "@dicebear/big-ears" "9.4.2"
+    "@dicebear/big-ears-neutral" "9.4.2"
+    "@dicebear/big-smile" "9.4.2"
+    "@dicebear/bottts" "9.4.2"
+    "@dicebear/bottts-neutral" "9.4.2"
+    "@dicebear/croodles" "9.4.2"
+    "@dicebear/croodles-neutral" "9.4.2"
+    "@dicebear/dylan" "9.4.2"
+    "@dicebear/fun-emoji" "9.4.2"
+    "@dicebear/glass" "9.4.2"
+    "@dicebear/icons" "9.4.2"
+    "@dicebear/identicon" "9.4.2"
+    "@dicebear/initials" "9.4.2"
+    "@dicebear/lorelei" "9.4.2"
+    "@dicebear/lorelei-neutral" "9.4.2"
+    "@dicebear/micah" "9.4.2"
+    "@dicebear/miniavs" "9.4.2"
+    "@dicebear/notionists" "9.4.2"
+    "@dicebear/notionists-neutral" "9.4.2"
+    "@dicebear/open-peeps" "9.4.2"
+    "@dicebear/personas" "9.4.2"
+    "@dicebear/pixel-art" "9.4.2"
+    "@dicebear/pixel-art-neutral" "9.4.2"
+    "@dicebear/rings" "9.4.2"
+    "@dicebear/shapes" "9.4.2"
+    "@dicebear/thumbs" "9.4.2"
+    "@dicebear/toon-head" "9.4.2"
+
+"@dicebear/core@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/core/-/core-9.4.2.tgz#8c15c7ef20e598228240a0fbfb173fe34d01f0bb"
+  integrity sha512-MF0042+Z3s8PGZKZLySfhft28bUa3B1iq0e5NSjCvY8gfMi5aIH/iRJGRJa1N9Jz1BNkxYb4yvJ/N9KO8Z6Y+w==
+  dependencies:
+    "@types/json-schema" "^7.0.15"
+
+"@dicebear/croodles-neutral@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/croodles-neutral/-/croodles-neutral-9.4.2.tgz#74b31e97757db016679e5eb3de75ab68f7eb26c4"
+  integrity sha512-oG5IeUdtiYshQ89gkAVcl5w3xAEi5UZX2fTzIyelpBPCG176l7VuuFzlxi2umnB3E6LVHYy06DXvUo/p+rXB2Q==
+
+"@dicebear/croodles@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/croodles/-/croodles-9.4.2.tgz#d5a29f2f30746cf9e1fa8ecb26272a7d4382cfac"
+  integrity sha512-6VoO0JviIf7dKKMBTL/SMXxWhnXHaZuzufX90G0nXxS77ELG1YkGNMaZzawizN4C09Gbya2gJkozqrWiJN/aGw==
+
+"@dicebear/dylan@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/dylan/-/dylan-9.4.2.tgz#d7b3905b2be999aab2a51aab69545db47301871a"
+  integrity sha512-1vQvRu9x9DrwFxhFaIU2rf0EUL04yDTbAt7fHyAjM0mEsKzTD4mRNf95tCRuavCoW6W48u7A/OY6jyIub6kxLQ==
+
+"@dicebear/fun-emoji@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/fun-emoji/-/fun-emoji-9.4.2.tgz#4b48663c1d79dfd7e4e5e5783d9ff24192ac42a0"
+  integrity sha512-kqB6LPkdYCdEU/mwbyz34xLzoNUKL6ARcoo3fr5ASq9D6ZE07qIKybC3xv5+CPz7VmspJ1Q3c/VVWVMDRP7Twg==
+
+"@dicebear/glass@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/glass/-/glass-9.4.2.tgz#608d93350c39158361c3b3c2ae392a179c3b20dd"
+  integrity sha512-z5qUogHQ1b6UJ2zCqT848mU2U9DKbVDhiX6GPDjD7tYLisCCJVisH9p6WyNdHvflUd4SHkA6gRqVJIh2v2HnTA==
+
+"@dicebear/icons@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/icons/-/icons-9.4.2.tgz#92d32d8d1150a786833424f2c323207e3e4e6a2e"
+  integrity sha512-QSMMz0NA03ypSGhXC8HQX8FSj8lYT+/5yqH+/N03OH2IjL0q7wwGZ7nqsrtlRp76O5WqMTwGfSbTUUYPjFr+Xw==
+
+"@dicebear/identicon@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/identicon/-/identicon-9.4.2.tgz#b72f8fb9874218598b12b03526dcadd051b33849"
+  integrity sha512-JVDSmZsv11mSWqwAktK5x9Bslht2xY3TFUn8xzu6slAYe1Z7hEXZ76eb+UJ6F4qEzdwZ7xPWzAS6Nb0Y3A0pww==
+
+"@dicebear/initials@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/initials/-/initials-9.4.2.tgz#6eab64a9913e57dac41a5a508f2fe68c7eb23c1b"
+  integrity sha512-yePuIUasmwtl9IrtB6rEzE/zb5fImKP/neW0CdcTC2MwLgMuP1GLHEGRgg1zI8exIh+PMv1YdLGyyUuRTE2Qpw==
+
+"@dicebear/lorelei-neutral@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/lorelei-neutral/-/lorelei-neutral-9.4.2.tgz#88da92634c0c18145a65611c00ece78e6d783bea"
+  integrity sha512-yspanTthA5vh6iCdeLzn6xZ4yYMYRcfcxblcgSvHTF1ut0bjAXtw5SXzZ6aJTrJWiHkzYOQuTOR6GVYiW80Q7w==
+
+"@dicebear/lorelei@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/lorelei/-/lorelei-9.4.2.tgz#bb37c41cac61e1878b09a819c4f50153b8d50d05"
+  integrity sha512-YMv6vnriW6VLFDsreKuOnUFFno6SRe7+7X7R7zPY0rZ+MaHX9V3jcioIG+1PSjIHEDfOLUHpr5vd1JBWv8y7UA==
+
+"@dicebear/micah@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/micah/-/micah-9.4.2.tgz#1ead10ff31d63a9c0fc55f4bb124a7782080b7ce"
+  integrity sha512-e4D3W/OlChSsLo7Llwsy0J18vk0azJqF/uFoY+EKACCNHBc1HGNsqVvu2CTf+OWOA8wTyAK6UkjBN5p01r7D+g==
+
+"@dicebear/miniavs@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/miniavs/-/miniavs-9.4.2.tgz#9971cfb7c72507a2d1cbda62ad3da9e38dc9196f"
+  integrity sha512-wLwyFNNUnDRd3BbhSBhXR0XEpX8sG0/xDA5M/OkDoapLqZnnI48YLUSDd2N5QTAVMmcSEuZOYxkcnj7WW79vlg==
+
+"@dicebear/notionists-neutral@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/notionists-neutral/-/notionists-neutral-9.4.2.tgz#08b99e589fdade9d7c8e79317eac19650ddefba4"
+  integrity sha512-AyD9kEfVxQUwDGf4Op059gVmYIOAkTKg3dtE9h9mEKP7zl/kMy5B67BFFOo7sB0mXCjzAegZ6ekGU02E8+hIHw==
+
+"@dicebear/notionists@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/notionists/-/notionists-9.4.2.tgz#9f7ee80a7793ab421e07c740bdc03a7c5bb7be70"
+  integrity sha512-ZCySq+nxcD/x4xyYgytcj2N9uY3gxrL+qpnmOdp2BdA221KacVrxlsUPpIgEMqxS2rMmBQXfxg129Pzn4ycIpA==
+
+"@dicebear/open-peeps@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/open-peeps/-/open-peeps-9.4.2.tgz#072dfb20ca9d47a72c40ba1e1b898feb0962ae10"
+  integrity sha512-i01tLgtp2g937T81sVeAOVlqsCtiTck/Kw20g7hN80+7xrXjOUepz2HPLy3HeiMjwjMGRy5o54kSd0/8Ht4Dqg==
+
+"@dicebear/personas@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/personas/-/personas-9.4.2.tgz#9fe6affb3da3c7b8c9c546bc7a4aff587ee8bcd2"
+  integrity sha512-NJlkvI5F5gugt6t2+7QrYNTwQC7+4IQZS3vG0dYk2BncxOHax0BuLovdSdiAesTL4ZkytFYIydWmKmV2/xcUwg==
+
+"@dicebear/pixel-art-neutral@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/pixel-art-neutral/-/pixel-art-neutral-9.4.2.tgz#781faf023f1be3c6576a3bb366d4aa93efd34a7d"
+  integrity sha512-9e9Lz554uQvWaXV2P17ss+hPa6rTyuAKBtB8zk8ECjHiZzIl61N/KcTVLZ4dILVZwj7gYriaLo16QEqvL2GJCg==
+
+"@dicebear/pixel-art@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/pixel-art/-/pixel-art-9.4.2.tgz#02e2643a3ea3f45af88d44f067c8bdfe830073ee"
+  integrity sha512-peHf7oKICDgBZ8dUyj+txPnS7VZEWgvKE+xW4mNQqBt6dYZIjmva2shOVHn0b1JU+FDxMx3uIkWVixKdUq4WGg==
+
+"@dicebear/rings@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/rings/-/rings-9.4.2.tgz#073a4a7b9c9782db8f767023cbbcdaa1024cc59d"
+  integrity sha512-Pc3ymWrRDQPJFNrbbLt7RJrzGvUuuxUiDkrfLhoVE+B6mZWEL1PC78DPbS1yUWYLErJOpJuM2GSwXmTbVjWf+g==
+
+"@dicebear/shapes@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/shapes/-/shapes-9.4.2.tgz#a3509c51fe9eca05e09a499be42536b93461b10b"
+  integrity sha512-AFL6jAaiLztvcqyq+ds+lWZu6Vbp3PlGWhJeJRm842jxtiluJpl6r4f6nUXP2fdMz7MNpDzXfLooQK9E04NbUQ==
+
+"@dicebear/thumbs@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/thumbs/-/thumbs-9.4.2.tgz#674ca17c154ecce89d2ba5c05a5f72af616ab269"
+  integrity sha512-ccWvDBqbkWS5uzHbsg5L6uML6vBfX7jT3J3jHCQksvz8haHItxTK02w+6e1UavZUsvza4lG5X/XY3eji3siJ4Q==
+
+"@dicebear/toon-head@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/toon-head/-/toon-head-9.4.2.tgz#af904b7c73b7c7e555e9c55ecea830009de0d9f4"
+  integrity sha512-lwFeSXyAnaKnCfMt9TiJwnD1cXQUGkey/0h6i/+4TVHVMCz5/Ri5u1ynovPNHy1SnBf858QwoXHkxilGLwQX/g==
+
 "@emotion/babel-plugin@^11.11.0":
   version "11.11.0"
   resolved "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz"
@@ -363,7 +562,7 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@mui/base@^5.0.0-beta.17", "@mui/base@5.0.0-beta.19":
+"@mui/base@5.0.0-beta.19", "@mui/base@^5.0.0-beta.17":
   version "5.0.0-beta.19"
   resolved "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.19.tgz"
   integrity sha512-maNBgAscddyPNzFZQUJDF/puxM27Li+NqSBsr/lAP8TLns2VvWS2SoL3OKFOIoRnAMKGY/Ic6Aot6gCYeQnssA==
@@ -502,6 +701,46 @@
   dependencies:
     glob "7.1.7"
 
+"@next/swc-darwin-arm64@13.5.3":
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.3.tgz#f72eac8c7b71d33e0768bd3c8baf68b00fea0160"
+  integrity sha512-6hiYNJxJmyYvvKGrVThzo4nTcqvqUTA/JvKim7Auaj33NexDqSNwN5YrrQu+QhZJCIpv2tULSHt+lf+rUflLSw==
+
+"@next/swc-darwin-x64@13.5.3":
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.3.tgz#96eda3a1247a713579eb241d76d3f503291c8938"
+  integrity sha512-UpBKxu2ob9scbpJyEq/xPgpdrgBgN3aLYlxyGqlYX5/KnwpJpFuIHU2lx8upQQ7L+MEmz+fA1XSgesoK92ppwQ==
+
+"@next/swc-linux-arm64-gnu@13.5.3":
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.3.tgz#132e155a029310fffcdfd3e3c4255f7ce9fd2714"
+  integrity sha512-5AzM7Yx1Ky+oLY6pHs7tjONTF22JirDPd5Jw/3/NazJ73uGB05NqhGhB4SbeCchg7SlVYVBeRMrMSZwJwq/xoA==
+
+"@next/swc-linux-arm64-musl@13.5.3":
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.3.tgz#981d7d8fdcf040bd0c89588ef4139c28805f5cf1"
+  integrity sha512-A/C1shbyUhj7wRtokmn73eBksjTM7fFQoY2v/0rTM5wehpkjQRLOXI8WJsag2uLhnZ4ii5OzR1rFPwoD9cvOgA==
+
+"@next/swc-linux-x64-gnu@13.5.3":
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.3.tgz#b8263663acda7b84bc2c4ffa39ca4b0172a78060"
+  integrity sha512-FubPuw/Boz8tKkk+5eOuDHOpk36F80rbgxlx4+xty/U71e3wZZxVYHfZXmf0IRToBn1Crb8WvLM9OYj/Ur815g==
+
+"@next/swc-linux-x64-musl@13.5.3":
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.3.tgz#cd0bed8ee92032c25090bed9d95602ac698d925f"
+  integrity sha512-DPw8nFuM1uEpbX47tM3wiXIR0Qa+atSzs9Q3peY1urkhofx44o7E1svnq+a5Q0r8lAcssLrwiM+OyJJgV/oj7g==
+
+"@next/swc-win32-arm64-msvc@13.5.3":
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.3.tgz#7f556674ca97e6936220d10c58252cc36522d80a"
+  integrity sha512-zBPSP8cHL51Gub/YV8UUePW7AVGukp2D8JU93IHbVDu2qmhFAn9LWXiOOLKplZQKxnIPUkJTQAJDCWBWU4UWUA==
+
+"@next/swc-win32-ia32-msvc@13.5.3":
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.3.tgz#4912721fb8695f11daec4cde42e73dc57bcc479f"
+  integrity sha512-ONcL/lYyGUj4W37D4I2I450SZtSenmFAvapkJQNIJhrPMhzDU/AdfLkW98NvH1D2+7FXwe7yclf3+B7v28uzBQ==
+
 "@next/swc-win32-x64-msvc@13.5.3":
   version "13.5.3"
   resolved "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.3.tgz"
@@ -515,7 +754,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -544,6 +783,11 @@
   integrity sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==
   dependencies:
     tslib "^2.4.0"
+
+"@types/json-schema@^7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
+  integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -966,7 +1210,7 @@ chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-client-only@^0.0.1, client-only@0.0.1:
+client-only@0.0.1, client-only@^0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
@@ -990,15 +1234,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@^1.0.8:
   version "1.0.8"
@@ -1650,6 +1894,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.1:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -1695,7 +1944,7 @@ get-tsconfig@^4.5.0:
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
-glob-parent@^5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -1709,22 +1958,15 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob-parent@~5.1.2:
-  version "5.1.2"
-  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
-  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
-  dependencies:
-    is-glob "^4.0.1"
-
 glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@^7.1.3, glob@7.1.7:
-  version "7.1.7"
-  resolved "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz"
-  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+glob@7.1.6:
+  version "7.1.6"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1733,10 +1975,10 @@ glob@^7.1.3, glob@7.1.7:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.6:
-  version "7.1.6"
-  resolved "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+glob@7.1.7, glob@^7.1.3:
+  version "7.1.7"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -2237,7 +2479,7 @@ jss-plugin-vendor-prefixer@^10.10.0:
     css-vendor "^2.0.8"
     jss "10.10.0"
 
-jss@^10.10.0, jss@10.10.0:
+jss@10.10.0, jss@^10.10.0:
   version "10.10.0"
   resolved "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz"
   integrity sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==
@@ -2391,7 +2633,7 @@ motion-utils@^12.39.0:
   resolved "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz"
   integrity sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==
 
-ms@^2.1.1, ms@2.1.2:
+ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -2675,21 +2917,21 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.23, postcss@8.4.30:
-  version "8.4.30"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz"
-  integrity sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==
-  dependencies:
-    nanoid "^3.3.6"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
-
 postcss@8.4.14:
   version "8.4.14"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz"
   integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==
   dependencies:
     nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
+postcss@8.4.30, postcss@^8.4.23:
+  version "8.4.30"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz"
+  integrity sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==
+  dependencies:
+    nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
@@ -2740,12 +2982,7 @@ react-icons@^4.11.0:
   resolved "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz"
   integrity sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==
 
-react-is@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react-is@^16.7.0:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -2915,12 +3152,7 @@ scheduler@^0.23.0:
   dependencies:
     loose-envify "^1.1.0"
 
-semver@^6.3.0:
-  version "6.3.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
-semver@^6.3.1:
+semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==


### PR DESCRIPTION
## Summary
Re-applies the alumni card redesign from `aditya-jaggi-probation` / PR #43 on top of **current main**. The original branch came from before PR #44 (alumni search) was merged, so merging it as-is would have **silently removed `MemberSearch`** and the new hero.

## What changed (conflict resolution)
- `components/team/AlumCard.tsx` — the redesigned card from PR #43: dicebear-initials fallback when no photo, hover lift + accent bar, social icons overlaid on photos for featured (coordinators/leads) roles, avatar fallback for members.
- `data/alumni.ts` — added `image?: string` to `Alum`. **Did NOT copy** the PR's bogus image assignments (`aaditya-3.jpg` reused for 3 different people, nonexistent `/images/team/default.png`); dicebear fallback covers everyone instead. No wrong-person photos ship.
- `app/alumni/page.tsx` — **kept** main's TypewriterEffect hero header + background, `Stagger` reveals, and **`MemberSearch`** in the Members section. Widened section grids (`max-w-7xl`, centered, larger gap) to fit the new fixed-size cards.
- `components/alumni/MemberSearch.tsx` — grid updated to `justify-items-center` + larger gaps so the new 230px cards stay centered.
- **Dep fix:** PR declared `@dicebear/core@^10` + `@dicebear/collection@9` — incompatible pair (v10 style packages aren't published). Pinned both to `9.4.2` (verified API: `createAvatar(initials,...).toDataUri()` works).

## Merge order (important)
Merge **after the Projects showcase PR** (`chore/projects-page-reapplied`): both branches touch `package.json`/`yarn.lock`, and the projects PR should land first so this branch's lockfile rebases cleanly.

## Verification
- `tsc --noEmit` ✅
- `yarn build` ✅ (/alumni 18.4 kB route compiles)